### PR TITLE
Make Elemental.load() accept HTML with multiple root nodes.

### DIFF
--- a/spec/elemental_spec.js
+++ b/spec/elemental_spec.js
@@ -38,6 +38,13 @@ describe("Elemental", function(){
           expect(bar).toHaveBeenCalled();
       });
 
+      it("should load behaviors on all top-level container elements", function() {
+          bar = jasmine.createSpy('bar');
+          var container = "<div data-behavior='bar'> </div>   <div data-behavior='bar'> </div>";
+          Elemental.load(container);
+          expect(bar.callCount).toEqual(2);
+      });
+
       describe("when the container is some specific DOM", function() {
         it("should load a behavior nested deeply beneath the container element", function() {
             baz = jasmine.createSpy('baz');

--- a/src/elemental.js
+++ b/src/elemental.js
@@ -29,12 +29,7 @@
     };
 
     ns.load = function(container) {
-        var $selector;
-        $selector = $('[data-behavior]', container);
-
-        if ($(container).data('behavior')) {
-            $selector = $selector.add(container);
-        }
+        var $selector = $('[data-behavior]', container).add($(container).filter('[data-behavior]'));
 
         $selector.each(function(index, element) {
             var $element = $(element);


### PR DESCRIPTION
This allows you to do:

```
Elemental.load('<div data-behavior="hi"></div>  <div data-behavior="bye"></div>');
```

Before you could only have a data-behavior on the only root level element.

If you upgrade to jQuery 1.8, then line 32 of src/elemental.js could become:

```
var $selector =  $('[data-behavior]', container).andSelf('[data-behavior]');
```
