### PR TITLE
Set the bower jquery dependency to any version newer than or equal to 1.7.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "spec"
   ],
   "dependencies": {
-    "jquery": "1.7.2"
+    "jquery": ">= 1.7.2"
   },
   "devDependencies": {
     "jasmine": "1.3.2"


### PR DESCRIPTION
We're using some other packages that depend on the newer versions of jquery (>= 2.0.0). At a glance I don't see anything in elementaljs that the newer versions of jquery don't support.
