### PR TITLE
Support class based behaviors

### DIFF
--- a/spec/elemental_spec.js
+++ b/spec/elemental_spec.js
@@ -45,6 +45,38 @@ describe("Elemental", function(){
           expect(bar.callCount).toEqual(2);
       });
 
+      it("should load the behavior as a function", function() {
+          var scope = null;
+          klass = function() {
+              scope = this;
+          };
+
+          var container = "<div><div><div><div data-behavior='klass'> </div></div></div></div>";
+          Elemental.load(container);
+          expect(scope).toEqual(window);
+      });
+
+      describe("when Elemental.options.classBased is true", function() {
+        beforeEach(function() {
+            Elemental.options.classBased = true;
+        });
+
+        afterEach(function() {
+            Elemental.options.classBased = false;
+        });
+
+        it("should load the behavior as a class using the new operator", function() {
+            var scope = null;
+            klass = function() {
+                scope = this;
+            };
+
+            var container = "<div><div><div><div data-behavior='klass'> </div></div></div></div>";
+            Elemental.load(container);
+            expect(scope).toNotEqual(window);
+        });
+      });
+
       describe("when the container is some specific DOM", function() {
         it("should load a behavior nested deeply beneath the container element", function() {
             baz = jasmine.createSpy('baz');

--- a/src/elemental.js
+++ b/src/elemental.js
@@ -20,7 +20,11 @@
         });
 
         if(typeof fn === 'function') {
-            return fn($element);
+            if(ns.options.classBased) {
+                return new fn($element);
+            } else {
+                return fn($element);
+            }
         } else {
             if (window.console && console.warn) {
                 console.warn("elementalJS: Unable to find behavior:", behavior);
@@ -34,6 +38,10 @@
         behaviors.replace(/([^ ]+)/g, function(behavior) {
             attachBehavior($element, behavior);
         });
+    };
+
+    ns.options = {
+        classBased: false
     };
 
     ns.loadOnly = function(element) {


### PR DESCRIPTION
An option to support class based behaviors that are easy to create with coffeescript (and ES6):

```coffee
class behaviors.klassBasedBehavior
  constructor: (@el) ->
    @el.on 'click', ->
    ...
```

This would still require an update to the readme, and I'm open to a more elegant way to do the spec, but I wasn't aware of a way to use jasmine spies to test this.