### PR TITLE
Add package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "elementaljs",
+  "version": "1.0.0",
+  "description": "Add behavior to your elements.",
+  "main": "src/elemental.js",
+  "scripts": {
+    "test": "rake jasmine"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elementaljs/elementaljs.git"
+  },
+  "author": "Robbie Clutton",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/elementaljs/elementaljs/issues"
+  },
+  "homepage": "https://github.com/elementaljs/elementaljs#readme"
+}


### PR DESCRIPTION
So elemental can be installed w/ NPM. I've tested this with Webpack. I was able to require elemental with `require('elementaljs');` and the behaviors with `require('elementaljs/src/behaviors/onload');`. This allows for installing elemental via GitHub w/ NPM though it'd be neat to also see this officially published to NPM as well.
